### PR TITLE
imazing - Fix 2.13.9 checksum

### DIFF
--- a/imazing/imazing.nuspec
+++ b/imazing/imazing.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>imazing</id>
     <title>imazing</title>
-    <version>2.13.9</version>
+    <version>2.13.9.20210725</version>
     <authors>DigiDNA</authors>
     <owners>MANICX100</owners>
     <summary>iMazing is mobile device management software that allows users to transfer files and data between iOS devices Computers without the limitations of iTunes.</summary>

--- a/imazing/tools/chocolateyinstall.ps1
+++ b/imazing/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ $installerType = 'exe'
 $silentArgs = '/VERYSILENT'
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url = 'https://downloads.imazing.com/windows/iMazing/iMazing2forWindows.exe'
-$checksum = '47CB3FD7A9942DB6F79E75A6D80922B7CA7368216C2840B046DDE177E3F7F8B8'
+$checksum = '5889823805307E6D1A3188A22528CE04B02E41B9C9869C065D9AD2A2F8FE5144'
 $checksumType = 'sha256'
 $validExitCodes = @(0)
  


### PR DESCRIPTION
I tried to update imazing earlier with the recently approved 2.13.9 package, but it failed with a checksum error:

```
Error - hashes do not match. Actual value was '5889823805307E6D1A3188A22528CE04B02E41B9C9869C065D9AD2A2F8FE5144'.
ERROR: Checksum for 'C:\Users\Brian\AppData\Local\Temp\chocolatey\imazing\2.13.9\iMazing2forWindows.exe' did not meet '47CB3FD7A9942DB6F79E75A6D80922B7CA7368216C2840B046DDE177E3F7F8B8' for checksum type 'sha256'. Consider passing the actual checksums through with --checksum --checksum64 once you validate the checksums are appropriate. A less secure option is to pass --ignore-checksums if necessary.
The upgrade of imazing was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\imazing\tools\chocolateyinstall.ps1'.
 See log for details.
```

Tried redownloading at least 3 times (inside and outside of Chocolatey), and got this checksum mismatch every time.

It's not clear to me if the original checksum was incorrect or if the binary was silently updated after being published. Regardless, I've updated the package with the new checksum and bumped the package's version using package fix notation.