### PR TITLE
Update PS Remote Play to 4.5.0.08250

### DIFF
--- a/ps-remote-play/ps-remote-play.nuspec
+++ b/ps-remote-play/ps-remote-play.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>ps-remote-play</id>
     <title>PlayStation Remote Play</title>
-    <version>4.1.0</version>
+    <version>4.5.0.08250</version>
     <authors>Sony</authors>
     <owners>MANICX100</owners>
     <summary>Remotely connect and control your PS4/PS5 System.</summary>

--- a/ps-remote-play/tools/chocolateyinstall.ps1
+++ b/ps-remote-play/tools/chocolateyinstall.ps1
@@ -3,7 +3,7 @@ $installerType = 'exe'
 $silentArgs = '/S /v/qn'
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url = 'https://remoteplay.dl.playstation.net/remoteplay/module/win/RemotePlayInstaller.exe'
-$checksum = '3A29E633AFCB08D170A33BD9126C35A7A3A931BD69B7CB6FE614CEF9ABA000A0'
+$checksum = '8F71ABDA6E2F227CB0EDB79ED4FD5617EC727BE8D81C1A7919241292AC946CF9'
 $checksumType = 'sha256'
 $validExitCodes = @(0)
  


### PR DESCRIPTION
The latest published package version is broken, due to the checksum being out-of-date. Fixing this.