### PR TITLE
Automate package updates via AU

### DIFF
--- a/ps-remote-play/update.ps1
+++ b/ps-remote-play/update.ps1
@@ -1,0 +1,33 @@
+Import-Module au
+
+function global:au_BeforeUpdate ($Package)  {
+    
+}
+
+function global:au_AfterUpdate ($Package)  {
+    
+}
+
+function global:au_SearchReplace {
+    @{
+        'tools\chocolateyinstall.ps1' = @{
+            "(^[$]checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+        }
+    }
+}
+
+function global:au_GetLatest {
+    $downloadUrl = "https://remoteplay.dl.playstation.net/remoteplay/module/win/RemotePlayInstaller.exe"
+
+    $tempFile = New-TemporaryFile
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile
+    $softwareVersion = $tempFile.VersionInfo.ProductVersion
+    Remove-Item -Path $tempFile -Force
+
+    return @{ 
+        Url32 = $downloadUrl;
+        Version = $softwareVersion
+    }
+}
+
+Update-Package -ChecksumFor 32 -NoReadme


### PR DESCRIPTION
This changeset implements an update script that utilizes the [Chocolatey Automatic Package Updater Module](https://community.chocolatey.org/packages/au), to assist with keeping this package up to date.

To test:
1. `choco install au`
2. Execute `.\update.ps1`.

`ps-remote-play.nuspec` and `chocolateyinstall.ps1` should be updated as needed, and a new package that consumes the updated files will be automatically packed.

The package is also currently outdated (latest version as of now is v5.0.0.0220). I've tested the script locally against the updated version, and it appears to work as I'd expect.