### PR TITLE
iMazing - Fix AU

### DIFF
--- a/imazing/imazing.nuspec
+++ b/imazing/imazing.nuspec
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">  
   <metadata>
     <id>imazing</id>
     <title>imazing</title>
-    <version></version>
+    <version>2.14.6.0</version>
     <authors>DigiDNA</authors>
     <owners>MANICX100</owners>
     <summary>iMazing is mobile device management software that allows users to transfer files and data between iOS devices Computers without the limitations of iTunes.</summary>

--- a/imazing/tools/chocolateyinstall.ps1
+++ b/imazing/tools/chocolateyinstall.ps1
@@ -1,9 +1,9 @@
-$packageName = 'imazing'
+﻿$packageName = 'imazing'
 $installerType = 'exe'
 $silentArgs = '/VERYSILENT'
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $url = 'https://downloads.imazing.com/windows/iMazing/iMazing2forWindows.exe'
-$checksum = ''
+$checksum = '442921a2bd651a7f83cd86ef9243481a197a0d9b1971bc4267f99c0b01b784d1'
 $checksumType = 'sha256'
 $validExitCodes = @(0)
  

--- a/imazing/update.ps1
+++ b/imazing/update.ps1
@@ -21,7 +21,7 @@ function global:au_GetLatest {
 
     $tempFile = New-TemporaryFile
     Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile
-    $softwareVersion = $tempFile.VersionInfo.ProductVersion
+    $softwareVersion = $tempFile.VersionInfo.ProductVersion.Trim()
     Remove-Item -Path $tempFile -Force
 
     return @{ 


### PR DESCRIPTION
Per https://github.com/MANICX100/chocolatey/pull/9#issuecomment-1083387238, I cloned the current script and tried running it on my end.

In iMazing's case, it seems the `ProductVersion` string has a bunch of trailing whitespace characters, and that's causing the version parsing to choke:
```ps1
PS D:\Local\Repositories\Git\chocolatey-packages-MANICX100\imazing> .\update.ps1
imazing - checking updates using au version 2021.7.18
C:\Users\brian\AppData\Local\Temp\tmp7CF8.tmp
\2.14.6.0                                          \

WARNING: Invalid nuspec file Version '' - using 0.0
Exception: D:\Cloud\Dropbox\Documents\PowerShell\Modules\au\2021.7.18\Public\Update-Package.ps1:210
Line |
 210 |  … ion $Latest.Version)) { throw "Invalid version: $($Latest.Version)" }
     |                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Invalid version: 2.14.6.0

```

Inspected by simply calling `Write-Host` on `$softwareVersion` and adding some boundary characters {`\` in my case).

After calling `Trim()` on `$softwareVersion`, the script is now behaving correctly.