### PR TITLE
PS Remote Play - Add explicit runtime dependencies

### DIFF
--- a/ps-remote-play/ps-remote-play.nuspec
+++ b/ps-remote-play/ps-remote-play.nuspec
@@ -19,6 +19,11 @@ Using the  [PS Remote Play] app, you can control your PlayStation®5 console or 
 #### Program
 * [News](https://remoteplay.dl.playstation.net/remoteplay/lang/gb/)
     </releaseNotes>
+    <dependencies>
+      <dependency id="webview2-runtime" version="100.0.1185.36" />
+      <dependency id="vcredist2013" version="12.0.30501.0" />
+      <dependency id="vcredist140" version="14.23.27820" />
+    </dependencies>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />


### PR DESCRIPTION
I've observed PS Remote Play's installer will grab the following runtime dependencies if they are not present during the installation process:
* Microsoft Edge WebView2 Runtime - Evergreen Runtime version (as of now, v100.0.1185.44)
* Microsoft Visual C++ 2013 Redistributable - v12.0.30501
* Microsoft Visual C++ 2015-2019 Redistributable - v14.23.27820

While not strictly necessary for the installation process to complete, the official [Package Creation Guide](https://docs.chocolatey.org/en-us/create/create-packages#rules-to-be-observed-before-publishing-packages)'s rules prefers these to be listed as explicit dependencies of the package:

> 8. **Don't include other required software if there's a package of it.** If a package requires other software of which there is already a package, the already existing package should be used as [dependency](https://docs.nuget.org/create/nuspec-reference#specifying-dependencies) instead.

This changeset adds Chocolatey package dependencies for the relevant programs to implement this rule's guidance.

**NOTE:** The dependency version discrepancy for `webview2-runtime` is intentional. I was unable to test a runtime version earlier than v100.0.1185.44, since the package implements the [Evergreen Runtime's bootstrapper distribution option](https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#the-evergreen-runtime-distribution-mode), and therefore always grabs the latest available version, regardless of whether the installed version matches the package version. However, the bootstrapper's checksum may not necessarily change between package versions. An earlier package version was declared to ensure we take a dependency on a pre-approved package version (as the relevant package version is currently stuck in moderation, and will fail to be resolved until approved), which currently installs a verified working software version.