### PR TITLE
PS Remote Play - Add licenseUrl

### DIFF
--- a/ps-remote-play/ps-remote-play.nuspec
+++ b/ps-remote-play/ps-remote-play.nuspec
@@ -12,6 +12,8 @@ With Remote Play, you can control your PlayStation® console remotely wherever y
 Using the  [PS Remote Play] app, you can control your PlayStation®5 console or PlayStation®4 console from a device in a different location.
 </description>
     <projectUrl>https://remoteplay.dl.playstation.net/remoteplay/</projectUrl>
+    <licenseUrl>https://doc.dl.playstation.net/doc/pc-app-eula/index.html</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <packageSourceUrl>https://github.com/MANICX100/chocolatey/tree/master/ps-remote-play</packageSourceUrl>
     <iconUrl>https://remoteplay.dl.playstation.net/remoteplay/images/icon-remote-play--normal.svg</iconUrl>
     <tags>ps4 ps5 playstation remote gaming</tags>


### PR DESCRIPTION
This changeset adds `licenseUrl` to the package's Nuspec to comply with Package Validator's guideline [CPMR0039](https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0039).

This will make the EULA easier to find, as the link is otherwise buried within [the software's download link source](https://remoteplay.dl.playstation.net/remoteplay/lang/en/ps5_win.html).