### PR TITLE
PS Remote Play - Enforce Windows 10 v1607 or later environment

### DIFF
--- a/ps-remote-play/ps-remote-play.nuspec
+++ b/ps-remote-play/ps-remote-play.nuspec
@@ -25,6 +25,7 @@ Using the  [PS Remote Play] app, you can control your PlayStation®5 console or 
       <dependency id="webview2-runtime" version="100.0.1185.36" />
       <dependency id="vcredist2013" version="12.0.30501.0" />
       <dependency id="vcredist140" version="14.23.27820" />
+      <dependency id="chocolatey-os-dependency.extension" version="0.0.1" />
     </dependencies>
   </metadata>
   <files>

--- a/ps-remote-play/tools/chocolateyinstall.ps1
+++ b/ps-remote-play/tools/chocolateyinstall.ps1
@@ -6,6 +6,8 @@ $url = 'https://remoteplay.dl.playstation.net/remoteplay/module/win/RemotePlayIn
 $checksum = '7ca976a86c7a2f320a543beb09e73a221ef0c849b8b0de8295e2fb0f63722dcf'
 $checksumType = 'sha256'
 $validExitCodes = @(0)
+
+Confirm-Win10 14393
  
 Install-ChocolateyPackage -PackageName "$packageName" `
                           -FileType "$installerType" `


### PR DESCRIPTION
This changeset adds a dependency on a new extension package ([chocolatey-os-dependency.extension](https://community.chocolatey.org/packages/chocolatey-os-dependency.extension)) and uses it to enforce a minimum OS requirement for PS Remote Play.

This is intended to resolve two issues:

## Silent Failure on Pre-Windows 10 Environments
The [system requirements](https://remoteplay.dl.playstation.net/remoteplay/lang/en/ps5_win.html#section1) section explicitly declares a dependency on Windows 10 systems. If the installed command is invoked with the `--not-silent` switch, I've observed the installer will indeed catch on to the version discrepancy and fail the installation, as observed in the Chocolatey Test Environment (based on Windows Server 2012 R2):

![PS Remote Play Installer failure](https://user-images.githubusercontent.com/6869577/167351193-a33d8347-1152-4e49-907e-4ba4f96e74b0.png)

However, the installer executed by this package will still return an exit code of 0. Therefore, in a typical silent install, the package will give off the impression that the installation succeeded when it really failed. [This behavior can mislead users](https://docs.chocolatey.org/en-us/create/create-packages#install-only-on-some-versions-of-windows) into thinking the package is faulty when the root cause is really an unsupported environment for the software.

As a pre-installation step, the install script now calls a new function bundled with the extension (`Confirm-Win10`) to confirm the OS's major version. The script will explicitly fail at this point if the function does not pass, and therefore will avoid running the installer altogether:

```
PS C:\Users\Administrator\Desktop> choco install ps-remote-play --source . -y
Chocolatey v1.1.0
Installing the following packages:
ps-remote-play
By installing, you accept licenses for the packages.

ps-remote-play v5.0.0.02220
ps-remote-play package files install completed. Performing other installation steps.
OS Dependency Check: OSMajor = 6 OSBuild = 9600 Minimum Required Build = 14393
WARNING:   ** <Windows 10 Build 14393 or higher required.
ERROR: ScriptHalted
The install of ps-remote-play was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\ps-remote-play\tools\chocolateyinstall.ps1'.
 See log for details.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - ps-remote-play (exited -1) - Error while running 'C:\ProgramData\chocolatey\lib\ps-remote-play\tools\chocolateyinstal
l.ps1'.
 See log for details.
```

## Runtime Launch Failure in Early Windows 10 Builds
In testing the package on some Windows 10 VMs I had set up, I noticed PS Remote Play will successfully install on all Windows 10 versions, but fails to launch on any Windows 10 version prior to v1607 (Redstone 1, Anniversary Update):

![PS Remote Play Runtime Failure 1](https://user-images.githubusercontent.com/6869577/167356666-46b4a4aa-5200-4057-a490-1ea831cdc389.png)
![PS Remote Play Runtime Failure 2](https://user-images.githubusercontent.com/6869577/167356591-141a85c4-9f11-4df1-aae2-614e8192ff62.png)

Affected versions include v1507 (Threshold 1, RTM) and v1511 (Threshold 2, November Update).

I'm assuming this is an oversight on Sony's part, as typical consumer versions of Windows 10 carry an 18-month support cycle, and most installations should've long since been updated by now to a newer, supported version. It's unlikely these versions were tested due to them being effectively end-of-life for consumer machines. As Microsoft no longer maintains any non-Enterprise releases of these versions, I feel it's unlikely Sony would be willing to invest time and effort toward adding and maintaining support for these versions.

To work around this, `Confirm-Win10` is further qualified with an optional `$ReqBuild` parameter to correspond to v1607 ([build 14393](https://docs.microsoft.com/en-us/windows/release-health/release-information#historyTable_10)). Windows 10 builds prior to v1607 should be treated similarly to pre-Windows 10 builds, and will therefore fail installation to avoid a later runtime failure:

```
PS C:\Users\vagrant\Desktop> choco install ps-remote-play --source . -y
Chocolatey v1.1.0
Installing the following packages:
ps-remote-play
By installing, you accept licenses for the packages.

ps-remote-play v5.0.0.02220
ps-remote-play package files install completed. Performing other installation steps.
OS Dependency Check: OSMajor = 10 OSBuild = 10240 Minimum Required Build = 14393
WARNING:   ** Windows 10 Build 14393 or higher required.
ERROR: ScriptHalted
The install of ps-remote-play was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\ps-remote-play\tools\chocolateyinstall.ps1'.
 See log for details.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - ps-remote-play (exited -1) - Error while running 'C:\ProgramData\chocolatey\lib\ps-remote-play\tools\chocolateyinstall.ps1'.
 See log for details.
```