### PR TITLE
iMazing - Optimize away an unnecessary download during package update

### DIFF
--- a/imazing/update.ps1
+++ b/imazing/update.ps1
@@ -22,12 +22,14 @@ function global:au_GetLatest {
     $tempFile = New-TemporaryFile
     Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile
     $softwareVersion = $tempFile.VersionInfo.ProductVersion.Trim()
+    $checksum = (Get-FileHash -Path $tempFile -Algorithm SHA256).Hash.ToLower()
     Remove-Item -Path $tempFile -Force
 
     return @{ 
         Url32 = $downloadUrl;
+        Checksum32 = $checksum
         Version = $softwareVersion
     }
 }
 
-Update-Package -ChecksumFor 32 -NoReadme
+Update-Package -ChecksumFor None -NoReadme


### PR DESCRIPTION
The iMazing installer binary is being downloaded twice during an update: once in `au_GetLatest()` to perform the update check, and again during AU's `Update-Package` while executing `chocolateyinstall.ps1` for the purpose of calculating the checksum. Since  a hash calculation is not too computationally expensive these days, may as well get this out of the way while we're already working with a local copy. 