### PR TITLE
iMazing - Overhaul AU

### DIFF
--- a/imazing/imazing.nuspec
+++ b/imazing/imazing.nuspec
@@ -17,10 +17,7 @@ iMazing is mobile device management software that allows users to transfer files
     <copyright>DigiDNA</copyright>
     <licenseUrl>https://imazing.com/licensing-policy</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <releaseNotes>
-#### Program
-* [News](https://imazing.com/blog)
-    </releaseNotes>
+    <releaseNotes>https://downloads.imazing.com/windows/iMazing/2.15.7/release-notes.html</releaseNotes>
 	<dependencies>
 	  <dependency id="dotnetfx" />
     </dependencies>

--- a/imazing/imazing.nuspec
+++ b/imazing/imazing.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>imazing</id>
     <title>imazing</title>
-    <version>2.15.5.0</version>
+    <version>2.15.7.0</version>
     <authors>DigiDNA</authors>
     <owners>MANICX100</owners>
     <summary>iMazing is mobile device management software that allows users to transfer files and data between iOS devices Computers without the limitations of iTunes.</summary>

--- a/imazing/imazing.nuspec
+++ b/imazing/imazing.nuspec
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">  
+  <metadata>
+    <id>imazing</id>
+    <title>imazing</title>
+    <version>2.15.5.0</version>
+    <authors>DigiDNA</authors>
+    <owners>MANICX100</owners>
+    <summary>iMazing is mobile device management software that allows users to transfer files and data between iOS devices Computers without the limitations of iTunes.</summary>
+    <description>
+iMazing is mobile device management software that allows users to transfer files and data between iOS devices Computers without the limitations of iTunes.
+    </description>
+    <projectUrl>https://imazing.com/</projectUrl>
+	<packageSourceUrl>https://github.com/MANICX100/chocolatey/tree/master/imazing</packageSourceUrl>
+    <iconUrl>https://rawcdn.githack.com/MANICX100/chocolatey/e8893bd51ebbba471b4745262326770198db04d7/imazing/logo.svg</iconUrl>
+    <tags>ios imazing itunes</tags>
+    <copyright>DigiDNA</copyright>
+    <licenseUrl>https://imazing.com/licensing-policy</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>
+#### Program
+* [News](https://imazing.com/blog)
+    </releaseNotes>
+	<dependencies>
+	  <dependency id="dotnetfx" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/imazing/update.ps1
+++ b/imazing/update.ps1
@@ -11,25 +11,30 @@ function global:au_AfterUpdate ($Package)  {
 function global:au_SearchReplace {
     @{
         'tools\chocolateyinstall.ps1' = @{
+            "(^[$]url\s*=\s*)('.*')" = "`$1'$($Latest.Url32)'"
             "(^[$]checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
+        }
+        "$($Latest.PackageName).nuspec" = @{
+            "^(\s*<releaseNotes>).*(</releaseNotes>)$" = "`$1$($Latest.ReleaseNotes)`$2"
         }
     }
 }
 
 function global:au_GetLatest {
-    $downloadUrl = "https://downloads.imazing.com/windows/iMazing/iMazing2forWindows.exe"
+    $sparkleUri = 'https://downloads.imazing.com/com.DigiDNA.iMazing2Windows.xml'
+    $userAgent = 'Update checker of Chocolatey Community Package ''imazing'''
+    $page = Invoke-WebRequest -Uri $sparkleUri -UserAgent $userAgent -UseBasicParsing
+    $xmlDocument = [xml] $page.Content
+    $latestReleaseItem = $xmlDocument.rss.channel.item[0]
 
-    $tempFile = New-TemporaryFile
-    Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile
-    $softwareVersion = $tempFile.VersionInfo.ProductVersion.Trim()
-    $checksum = (Get-FileHash -Path $tempFile -Algorithm SHA256).Hash.ToLower()
-    Remove-Item -Path $tempFile -Force
+    $marketingVersion = $latestReleaseItem.enclosure.shortVersionString
+    $productVersion = "$($marketingVersion.ToString()).0"
 
     return @{ 
-        Url32 = $downloadUrl;
-        Checksum32 = $checksum
-        Version = $softwareVersion
+        Url32 = $latestReleaseItem.enclosure.url
+        Version = $productVersion
+        ReleaseNotes = $latestReleaseItem.releaseNotesLink
     }
 }
 
-Update-Package -ChecksumFor None -NoReadme
+Update-Package -ChecksumFor 32 -NoReadme


### PR DESCRIPTION
I recently discovered iMazing used a Sparkle feed to handle its auto-update functionality. Rewrote the update script around it. This could come in handy for a few reasons:
* Queries the exact same update feed used by iMazing itself. Should move in lockstep with update availability, and not depend on a website update.
* Unlike what's publicly shared, each release item uses a versioned download URL. These URLs should provide better long-term stability for the package, and not make old package versions obsolete when the unversioned binary changes.
* Optimizes the download and checksum steps away for version check purposes. These should now only execute when a new version is actually available. 