### PR TITLE
PS Remote Play - Use versioned download, update to 6.5.0.08180

### DIFF
--- a/ps-remote-play/ps-remote-play.nuspec
+++ b/ps-remote-play/ps-remote-play.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>ps-remote-play</id>
     <title>PlayStation Remote Play</title>
-    <version>6.0.0.02240</version>
+    <version>6.5.0.08180</version>
     <authors>Sony</authors>
     <owners>MANICX100</owners>
     <summary>Remotely connect and control your PS4/PS5 System.</summary>

--- a/ps-remote-play/tools/chocolateyinstall.ps1
+++ b/ps-remote-play/tools/chocolateyinstall.ps1
@@ -1,9 +1,9 @@
 ﻿$packageName = 'ps-remote-play'
-$installerType = 'exe'
-$silentArgs = '/S /v/qn'
+$installerType = 'MSI'
+$silentArgs = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = 'https://remoteplay.dl.playstation.net/remoteplay/module/win/RemotePlayInstaller.exe'
-$checksum = '84157138f75922b237d7cfb2af404c465528385ef85b2b6c097c4a22d998e17d'
+$url = 'https://remoteplay.dl.playstation.net/remoteplay/module/win/RemotePlayInstaller_6.5.0.08180_Win32.msi'
+$checksum = '9c36c405931dd465ce91bc5ccc2a16942500d16ffc3f262082b80dc0130eb62e'
 $checksumType = 'sha256'
 $validExitCodes = @(0)
 

--- a/ps-remote-play/update.ps1
+++ b/ps-remote-play/update.ps1
@@ -11,6 +11,7 @@ function global:au_AfterUpdate ($Package)  {
 function global:au_SearchReplace {
     @{
         'tools\chocolateyinstall.ps1' = @{
+            "(^[$]url\s*=\s*)('.*')" = "`$1'$($Latest.Url32)'"
             "(^[$]checksum\s*=\s*)('.*')" = "`$1'$($Latest.Checksum32)'"
         }
     }
@@ -25,7 +26,7 @@ function global:au_GetLatest {
     Remove-Item -Path $tempFile -Force
 
     return @{ 
-        Url32 = $downloadUrl;
+        Url32   = "https://remoteplay.dl.playstation.net/remoteplay/module/win/RemotePlayInstaller_$($softwareVersion)_Win32.msi"
         Version = $softwareVersion
     }
 }


### PR DESCRIPTION
The current installer consumed by the package is a web installer that downloads the latest version's MSI package, which hinders package internalization efforts by introducing a connectivity requirement to Sony's servers. The checksum of the web installer will also change with every release, which will break previous versions of the package.

This reworks the install script to consume the downloaded MSI directly, and tweaks the update process to use the web installer's version info to populate the MSI's download URL, which should improve the long-term stability of a given package version.

I've also updated the package for the latest release.