### PR TITLE
Deprecate repository for PS Remote Play

### DIFF
--- a/ps-remote-play/README.md
+++ b/ps-remote-play/README.md
@@ -1,0 +1,9 @@
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
+## ⛔️ REPOSITORY DEPRECATED
+
+This repository is no longer being used for this package, and exists only for archival purposes.
+
+Issues and pull requests should not be submitted here.
+
+This package is now being maintained at [brogers5/chocolatey-package-ps-remote-play](https://github.com/brogers5/chocolatey-package-ps-remote-play).


### PR DESCRIPTION
As a final step to the package handover process for `ps-remote-play`, I've added a repository deprecation notice. 

Since this copy of `ps-remote-play`'s source code is now outdated, and that I do not intend to monitor this repository for new issues/PRs relating to the package, this is my attempt to discourage any future issues/PRs relating to it, while also redirecting interested users toward the currently maintained copy.

Your efforts to get the `ps-remote-play` package up and running and maintaining it up to this point are much appreciated.

FYI, I typically remove inactive maintainers from packages I take over for security reasons. If you'd like to remain on as a backup maintainer, please let me know so I can add you as a collaborator. Otherwise, I'll go ahead and remove you so any future activity/inquiries relating to `ps-remote-play` won't clutter your inbox.